### PR TITLE
Fix typo in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ umount /dev/shm && mount -t tmpfs shm /dev/shm
 
 # using local electron module instead of the global electron lets you
 # easily control specific version dependency between your app and electron itself.
-# the syntax below starts an X istance with ONLY our electronJS fired up,
+# the syntax below starts an X instance with ONLY our electronJS fired up,
 # it saves you a LOT of resources avoiding full-desktops envs
 
 rm /tmp/.X0-lock &>/dev/null || true


### PR DESCRIPTION
## Summary
- correct "istance" to "instance" in startup script

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68402fe5108483208390a088028fced3